### PR TITLE
[DIAGNOSTIC TEST - NOT A FINAL FIX]

### DIFF
--- a/stepper-manager.js
+++ b/stepper-manager.js
@@ -139,21 +139,23 @@ class StepperManager {
             const roundedDiff = Math.round(diff);
 
             if (this.getCurrentUnit() === 'cm' && (roundedDiff === 1 || roundedDiff === -1)) {
+                // --- DIAGNOSTIC TEST ---
+                // Stop other event listeners from running to test for conflicts.
+                e.stopPropagation();
+
                 let correctedValue;
                 // Usar aritmética basada en enteros para evitar errores de punto flotante.
-                // Se convierte a décimas de cm, se opera y se vuelve a cm.
                 if (roundedDiff === 1) { // Incremento
                     correctedValue = (Math.round(oldValue * 10) + 1) / 10;
                 } else { // Decremento
                     correctedValue = (Math.round(oldValue * 10) - 1) / 10;
                 }
 
-                // El redondeo final aquí es una doble seguridad.
                 const finalValue = Math.max(0, Math.round(correctedValue * 10) / 10);
 
                 input.value = finalValue;
                 field.lastValue = finalValue.toString();
-                this.debounceInputEvent(input);
+                // Do not call debounceInputEvent during the test to avoid further complications.
 
             } else {
                 // Para otros casos (p.ej. el campo se vacía), actualizar el valor.


### PR DESCRIPTION
This commit contains a temporary diagnostic test to isolate an event listener conflict.

To debug a persistent issue with the numeric stepper, this build modifies the `input` event listener in `stepper-manager.js` to call `e.stopPropagation()`. This will prevent other listeners (specifically `mainController` in `app.js`) from running when the stepper is clicked.

This is intended to confirm whether the event listener conflict is the root cause of the bug. The expected outcome is that the input value will be correct, but other UI elements may not update.

This code should be reverted before the final fix is implemented.