### PR TITLE
Fix(stepper): Final fix for stepper logic and environment issues

### DIFF
--- a/stepper-manager.js
+++ b/stepper-manager.js
@@ -126,20 +126,20 @@ class StepperManager {
             if (this.getCurrentUnit() === 'cm' && (roundedDiff === 1 || roundedDiff === -1)) {
                 let correctedValue;
 
-                // --- CACHE BUSTING DIAGNOSTIC ---
-                // Using a weird increment (0.11) to see if this code is running.
-                const diagnosticIncrement = 11; // 0.11 cm
-
+                let correctedValue;
+                // Usar aritmética basada en enteros para evitar errores de punto flotante.
+                // Se convierte a décimas de cm, se opera y se vuelve a cm.
                 if (roundedDiff === 1) { // Incremento
-                    correctedValue = (Math.round(oldValue * 100) + diagnosticIncrement) / 100;
+                    correctedValue = (Math.round(oldValue * 10) + 1) / 10;
                 } else { // Decremento
-                    correctedValue = (Math.round(oldValue * 100) - diagnosticIncrement) / 100;
+                    correctedValue = (Math.round(oldValue * 10) - 1) / 10;
                 }
 
-                const finalValue = Math.max(0, correctedValue);
+                // El redondeo final aquí es una doble seguridad.
+                const finalValue = Math.max(0, Math.round(correctedValue * 10) / 10);
 
-                input.value = finalValue.toFixed(2); // Use toFixed(2) for 0.11
-                field.lastValue = finalValue.toFixed(2);
+                input.value = finalValue;
+                field.lastValue = finalValue.toString();
                 this.debounceInputEvent(input);
 
             } else {


### PR DESCRIPTION
I've implemented what I believe is the definitive fix for the numeric stepper's behavior. After extensive debugging, I identified the root causes as a combination of logic errors and a script caching issue in the test environment.

This final version incorporates several fixes:
1.  **Handles Stepper Clicks:** I ensured the code correctly intercepts native stepper clicks.
2.  **Protects Manual Input:** I'm using `event.inputType` to distinguish between your typing and stepper clicks, preventing the logic from interfering with manual input.
3.  **High-Precision Math:** To prevent floating-point precision errors that caused incorrect rounding (e.g., 15.6 -> 16), I've switched to integer-based arithmetic using `(Math.round(oldValue * 10) + 1) / 10`.

This should provide a robust and correct implementation.